### PR TITLE
Make SDL2 port playable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ second step:
 
 Compilation depends on the following libraries:
 
-* SDL 1.2
-* SDL_image 1.2
-* SDL_ttf 2.0
-* SDL_mixer 1.2
+* SDL2 2.0
+* SDL2_image 2.0
+* SDL2_ttf 2.0
+* SDL2_mixer 2.0
 
 These are often provided by GNU/Linux distributions. Under Debian, for
 instance, the following command installs the required libraries:
 
-    $ sudo apt install libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev
+    $ sudo apt install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
 
 ## License
 The Zatacka X code is free software, licensed under the GNU General

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -69,7 +69,6 @@ bool loadImage(Image i, const char *filename)
         printf("Loaded: %s\t(w:%d h:%d bpp:%d)\n", filename, images[i]->w,
                images[i]->h, 32);
     }
-    SDL_FreeSurface(loadedImage);
 
     free(file);
     return true;

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -28,7 +28,7 @@ SDL_Surface *images[N_IMAGES];
  */
 int clearSurface(SDL_Surface *s)
 {
-    /* Uint32 color = SDL_MapRGB(0, 0x00, 0x00, 0x00); */
+    Uint32 color = SDL_MapRGB(s->format, 0x00, 0x00, 0x00);
     return SDL_FillRect(s, &s->clip_rect, 0);
 }
 

--- a/src/input.c
+++ b/src/input.c
@@ -258,10 +258,13 @@ char *buttonName(button b)
     }
     else if ((b >= SDL_SCANCODE_A && b <= SDL_SCANCODE_Z)
                  || (b >= SDL_SCANCODE_0 && b <= SDL_SCANCODE_9)) {
-        snprintf(keyname, BUTTON_NAME_MAX_LEN, "%c", b);
+        snprintf(keyname, BUTTON_NAME_MAX_LEN, "%c", SDL_GetKeyFromScancode(b));
     }
-    else if (b >= SDL_SCANCODE_F1 && b <= SDL_SCANCODE_F15) {
+    else if (b >= SDL_SCANCODE_F1 && b <= SDL_SCANCODE_F12) {
         snprintf(keyname, BUTTON_NAME_MAX_LEN, "F%d", b - SDL_SCANCODE_F1 + 1);
+    }
+    else if (b >= SDL_SCANCODE_F13 && b <= SDL_SCANCODE_F15) {
+        snprintf(keyname, BUTTON_NAME_MAX_LEN, "F%d", b - SDL_SCANCODE_F13 + 13);
     }
     else {
         switch (b) {

--- a/src/input.c
+++ b/src/input.c
@@ -25,8 +25,8 @@ const int BUTTON_NAME_MAX_LEN = 20;
  */
 const Uint8 JOY_ENTER_BUTTON = 1;
 
-// 322 is the number of possible SDL keys (see SDL_keysym.h).
-bool keyDown[322];
+// Number of possible SDL keys (see SDL_scancode.h).
+bool keyDown[SDL_NUM_SCANCODES];
 
 /*
  * A separate map is kept for each possible joystick (0-7). See the
@@ -122,7 +122,7 @@ int axisNumber(SDL_JoyAxisEvent e)
  */
 bool enterButtonDown(void)
 {
-    if (keyDown[SDLK_SPACE] || keyDown[SDLK_RETURN]) {
+    if (keyDown[SDL_SCANCODE_SPACE] || keyDown[SDL_SCANCODE_RETURN]) {
         return true;
     }
 
@@ -140,8 +140,8 @@ bool enterButtonDown(void)
  */
 void clearEnterButtons(void)
 {
-    keyDown[SDLK_RETURN] = false;
-    keyDown[SDLK_SPACE] = false;
+    keyDown[SDL_SCANCODE_RETURN] = false;
+    keyDown[SDL_SCANCODE_SPACE] = false;
 
     for (unsigned int i = 0; i < numJoys; i++) {
         joyButtonDown[i][JOY_ENTER_BUTTON] = false;
@@ -179,11 +179,11 @@ void clearButton(button b)
  */
 bool menuButtonQuery(enum keySymbol ks)
 {
-    SDL_KeyCode lkeys[4][3] =
-        {{SDLK_UP,    SDLK_k, SDLK_p},
-         {SDLK_RIGHT, SDLK_l, SDLK_f},
-         {SDLK_DOWN,  SDLK_j, SDLK_n},
-         {SDLK_LEFT,  SDLK_h, SDLK_b}};
+    SDL_Scancode lkeys[4][3] =
+        {{SDL_SCANCODE_UP,    SDL_SCANCODE_K, SDL_SCANCODE_P},
+         {SDL_SCANCODE_RIGHT, SDL_SCANCODE_L, SDL_SCANCODE_F},
+         {SDL_SCANCODE_DOWN,  SDL_SCANCODE_J, SDL_SCANCODE_N},
+         {SDL_SCANCODE_LEFT,  SDL_SCANCODE_H, SDL_SCANCODE_B}};
 
     for (int i = 0; i < 3; i++) {
         if (keyDown[lkeys[ks][i]]) {
@@ -256,98 +256,98 @@ char *buttonName(button b)
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "joy-%s", axisName);
         }
     }
-    else if ((b >= SDLK_a && b <= SDLK_z)
-                 || (b >= SDLK_0 && b <= SDLK_9)) {
+    else if ((b >= SDL_SCANCODE_A && b <= SDL_SCANCODE_Z)
+                 || (b >= SDL_SCANCODE_0 && b <= SDL_SCANCODE_9)) {
         snprintf(keyname, BUTTON_NAME_MAX_LEN, "%c", b);
     }
-    else if (b >= SDLK_F1 && b <= SDLK_F15) {
-        snprintf(keyname, BUTTON_NAME_MAX_LEN, "F%d", b - SDLK_F1 + 1);
+    else if (b >= SDL_SCANCODE_F1 && b <= SDL_SCANCODE_F15) {
+        snprintf(keyname, BUTTON_NAME_MAX_LEN, "F%d", b - SDL_SCANCODE_F1 + 1);
     }
     else {
         switch (b) {
-        case SDLK_UNKNOWN:
+        case SDL_SCANCODE_UNKNOWN:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "none"); break;
-        case SDLK_LEFT:
+        case SDL_SCANCODE_LEFT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "left"); break;
-        case SDLK_RIGHT:
+        case SDL_SCANCODE_RIGHT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "right"); break;
-        case SDLK_UP:
+        case SDL_SCANCODE_UP:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "up"); break;
-        case SDLK_DOWN:
+        case SDL_SCANCODE_DOWN:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "down"); break;
-        /* case SDLK_SCROLLOCK: */
+        /* case SDL_SCANCODE_SCROLLOCK: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "scr-lk"); break; */
-        case SDLK_PAUSE:
+        case SDL_SCANCODE_PAUSE:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "pause"); break;
-        case SDLK_DELETE:
+        case SDL_SCANCODE_DELETE:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "del"); break;
-        case SDLK_INSERT:
+        case SDL_SCANCODE_INSERT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "ins"); break;
-        case SDLK_HOME:
+        case SDL_SCANCODE_HOME:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "home"); break;
-        case SDLK_END:
+        case SDL_SCANCODE_END:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "end"); break;
-        case SDLK_MENU:
+        case SDL_SCANCODE_MENU:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "menu"); break;
-        /* case SDLK_PRINT: */
+        /* case SDL_SCANCODE_PRINT: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "prt-sc"); break; */
-        case SDLK_PAGEUP:
+        case SDL_SCANCODE_PAGEUP:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "pg up"); break;
-        case SDLK_PAGEDOWN:
+        case SDL_SCANCODE_PAGEDOWN:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "pg dn"); break;
-        case SDLK_RSHIFT:
+        case SDL_SCANCODE_RSHIFT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "r-shift"); break;
-        case SDLK_LSHIFT:
+        case SDL_SCANCODE_LSHIFT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "l-shift"); break;
-        case SDLK_RCTRL:
+        case SDL_SCANCODE_RCTRL:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "r-ctrl"); break;
-        case SDLK_LCTRL:
+        case SDL_SCANCODE_LCTRL:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "l-ctrl"); break;
-        case SDLK_RALT:
+        case SDL_SCANCODE_RALT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "r-alt"); break;
-        case SDLK_LALT:
+        case SDL_SCANCODE_LALT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "l-alt"); break;
-        case SDLK_MODE:
+        case SDL_SCANCODE_MODE:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "alt gr"); break;
-        /* case SDLK_RSUPER: */
+        /* case SDL_SCANCODE_RSUPER: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "r-super"); break; */
-        /* case SDLK_LSUPER: */
+        /* case SDL_SCANCODE_LSUPER: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "l-super"); break; */
-        case SDLK_TAB:
+        case SDL_SCANCODE_TAB:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "tab"); break;
-        case SDLK_PERIOD:
+        case SDL_SCANCODE_PERIOD:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "."); break;
-        case SDLK_COMMA:
+        case SDL_SCANCODE_COMMA:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, ","); break;
-        case SDLK_SEMICOLON:
+        case SDL_SCANCODE_SEMICOLON:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, ";"); break;
-        case SDLK_MINUS:
+        case SDL_SCANCODE_MINUS:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "-"); break;
-        case SDLK_QUOTE:
-            snprintf(keyname, BUTTON_NAME_MAX_LEN, "'"); break;
-        case SDLK_BACKQUOTE:
-            snprintf(keyname, BUTTON_NAME_MAX_LEN, "`"); break;
-        case SDLK_PLUS:
-            snprintf(keyname, BUTTON_NAME_MAX_LEN, "+"); break;
-        case SDLK_EQUALS:
+        // case SDL_SCANCODE_QUOTE:
+        //     snprintf(keyname, BUTTON_NAME_MAX_LEN, "'"); break;
+        // case SDL_SCANCODE_BACKQUOTE:
+        //     snprintf(keyname, BUTTON_NAME_MAX_LEN, "`"); break;
+        // case SDL_SCANCODE_PLUS:
+        //     snprintf(keyname, BUTTON_NAME_MAX_LEN, "+"); break;
+        case SDL_SCANCODE_EQUALS:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "="); break;
-        /* case SDLK_COMPOSE: */
+        /* case SDL_SCANCODE_COMPOSE: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "^"); break; */
-        case SDLK_SLASH:
+        case SDL_SCANCODE_SLASH:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "/"); break;
-        case SDLK_BACKSLASH:
+        case SDL_SCANCODE_BACKSLASH:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "\\"); break;
-        case SDLK_LESS:
-            snprintf(keyname, BUTTON_NAME_MAX_LEN, "<"); break;
-        case SDLK_LEFTBRACKET:
+        // case SDL_SCANCODE_LESS:
+        //     snprintf(keyname, BUTTON_NAME_MAX_LEN, "<"); break;
+        case SDL_SCANCODE_LEFTBRACKET:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "["); break;
-        case SDLK_RIGHTBRACKET:
+        case SDL_SCANCODE_RIGHTBRACKET:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "]"); break;
-        case SDLK_BACKSPACE:
+        case SDL_SCANCODE_BACKSPACE:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "b-space"); break;
-        case SDLK_RETURN:
+        case SDL_SCANCODE_RETURN:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "enter"); break;
-        case SDLK_SPACE:
+        case SDL_SCANCODE_SPACE:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "space"); break;
         case SDL_BUTTON_LEFT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "l-mouse"); break;
@@ -355,11 +355,11 @@ char *buttonName(button b)
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "m-mouse"); break;
         case SDL_BUTTON_RIGHT:
             snprintf(keyname, BUTTON_NAME_MAX_LEN, "r-mouse"); break;
-        /* case SDLK_WORLD_70: */
+        /* case SDL_SCANCODE_WORLD_70: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "æ"); break; */
-        /* case SDLK_WORLD_88: */
+        /* case SDL_SCANCODE_WORLD_88: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "ø"); break; */
-        /* case SDLK_WORLD_69: */
+        /* case SDL_SCANCODE_WORLD_69: */
         /*     snprintf(keyname, BUTTON_NAME_MAX_LEN, "å"); break; */
         default:
             break;

--- a/src/input.h
+++ b/src/input.h
@@ -8,7 +8,7 @@
 #include "common.h"
 
 extern const int BUTTON_NAME_MAX_LEN;
-extern bool keyDown[322];
+extern bool keyDown[SDL_NUM_SCANCODES];
 extern bool joyButtonDown[MAX_PLAYERS][128];
 
 /*

--- a/src/sound.c
+++ b/src/sound.c
@@ -25,8 +25,8 @@ Mix_Chunk *sounds[N_SOUNDS];
  */
 int initSound(void)
 {
-    /* return Mix_OpenAudio(MIX_DEFAULT_FREQUENCY * 2, MIX_DEFAULT_FORMAT, 2, */
-                         /* 512); */
+    return Mix_OpenAudio(MIX_DEFAULT_FREQUENCY * 2, MIX_DEFAULT_FORMAT, 2,
+                         512);
 }
 
 /**
@@ -35,18 +35,18 @@ int initSound(void)
  */
 bool loadSound(Sound s, const char *filename)
 {
-    /* char *file = dataFile("sound", filename); */
-    /* Mix_Chunk *sound = Mix_LoadWAV(file); */
+    char *file = dataFile("sound", filename);
+    Mix_Chunk *sound = Mix_LoadWAV(file);
 
-    /* if (sound == NULL) { */
-    /*     fileNotFound(file); */
-    /*     free(file); */
-    /*     return false; */
-    /* } */
+    if (sound == NULL) {
+        fileNotFound(file);
+        free(file);
+        return false;
+    }
 
-    /* sounds[s] = sound; */
-    /* free(file); */
-    /* return true; */
+    sounds[s] = sound;
+    free(file);
+    return true;
 }
 
 /**
@@ -55,17 +55,17 @@ bool loadSound(Sound s, const char *filename)
  */
 bool loadBGM(const char *filename)
 {
-    /* char *file = dataFile("sound", filename); */
-    /* bgm = Mix_LoadMUS(file); */
+    char *file = dataFile("sound", filename);
+    bgm = Mix_LoadMUS(file);
 
-    /* if (bgm == NULL) { */
-    /*     fileNotFound(file); */
-    /*     free(file); */
-    /*     return false; */
-    /* } */
+    if (bgm == NULL) {
+        fileNotFound(file);
+        free(file);
+        return false;
+    }
 
-    /* free(file); */
-    /* return true; */
+    free(file);
+    return true;
 }
 
 /**
@@ -74,29 +74,29 @@ bool loadBGM(const char *filename)
  */
 bool loadSounds(void)
 {
-    /* return loadBGM("theme1.ogg") */
-    /*     && loadSound(SOUND_BEP, "bep.ogg") */
-    /*     && loadSound(SOUND_BEEP, "beep.ogg") */
-    /*     && loadSound(SOUND_BEEEP, "beeep.ogg") */
-    /*     && loadSound(SOUND_BEEEEP, "beeeep.ogg") */
-    /*     && loadSound(SOUND_BEEEEEP, "beeeeep.ogg") */
-    /*     && loadSound(SOUND_BEEEEEEP, "beeeeeep.ogg") */
-    /*     && loadSound(SOUND_BEEEEEEEP, "beeeeeeep.ogg") */
-    /*     && loadSound(SOUND_BEEEEEEEEP, "beeeeeeeep.ogg") */
-    /*     && loadSound(SOUND_ROUND_BEGIN, "round_begin.ogg") */
-    /*     && loadSound(SOUND_CRASH, "crash.ogg") */
-    /*     && loadSound(SOUND_EXPLOSION, "explosion.ogg") */
-    /*     && loadSound(SOUND_SPEED, "speed.ogg") */
-    /*     && loadSound(SOUND_FREEZE, "freeze.ogg") */
-    /*     && loadSound(SOUND_CONFUSION, "confusion.ogg") */
-    /*     && loadSound(SOUND_SHARPTURN, "sharpturn.ogg") */
-    /*     && loadSound(SOUND_TIMESTEP, "timestep.ogg") */
-    /*     && loadSound(SOUND_MOLE, "mole.ogg") */
-    /*     && loadSound(SOUND_WARP, "warp.ogg") */
-    /*     && loadSound(SOUND_GHOST, "ghost.ogg") */
-    /*     && loadSound(SOUND_TRON, "tronmode.ogg") */
-    /*     && loadSound(SOUND_CHILIRUN, "chilirun.ogg") */
-    /*     && loadSound(SOUND_ROCKETLAUNCHER, "rocketlauncher.ogg"); */
+    return loadBGM("theme1.ogg")
+        && loadSound(SOUND_BEP, "bep.ogg")
+        && loadSound(SOUND_BEEP, "beep.ogg")
+        && loadSound(SOUND_BEEEP, "beeep.ogg")
+        && loadSound(SOUND_BEEEEP, "beeeep.ogg")
+        && loadSound(SOUND_BEEEEEP, "beeeeep.ogg")
+        && loadSound(SOUND_BEEEEEEP, "beeeeeep.ogg")
+        && loadSound(SOUND_BEEEEEEEP, "beeeeeeep.ogg")
+        && loadSound(SOUND_BEEEEEEEEP, "beeeeeeeep.ogg")
+        && loadSound(SOUND_ROUND_BEGIN, "round_begin.ogg")
+        && loadSound(SOUND_CRASH, "crash.ogg")
+        && loadSound(SOUND_EXPLOSION, "explosion.ogg")
+        && loadSound(SOUND_SPEED, "speed.ogg")
+        && loadSound(SOUND_FREEZE, "freeze.ogg")
+        && loadSound(SOUND_CONFUSION, "confusion.ogg")
+        && loadSound(SOUND_SHARPTURN, "sharpturn.ogg")
+        && loadSound(SOUND_TIMESTEP, "timestep.ogg")
+        && loadSound(SOUND_MOLE, "mole.ogg")
+        && loadSound(SOUND_WARP, "warp.ogg")
+        && loadSound(SOUND_GHOST, "ghost.ogg")
+        && loadSound(SOUND_TRON, "tronmode.ogg")
+        && loadSound(SOUND_CHILIRUN, "chilirun.ogg")
+        && loadSound(SOUND_ROCKETLAUNCHER, "rocketlauncher.ogg");
 }
 
 /**
@@ -107,8 +107,8 @@ bool loadSounds(void)
  */
 void playSound(unsigned int sound, int play)
 {
-    /* if (play) */
-    /*     Mix_PlayChannel(-1, sounds[sound], 0); */
+    if (play)
+        Mix_PlayChannel(-1, sounds[sound], 0);
 }
 
 /**
@@ -116,12 +116,12 @@ void playSound(unsigned int sound, int play)
  */
 void playBGM(void)
 {
-    /* if (!Mix_PlayingMusic()) { */
-    /*     if ((Mix_PlayMusic(bgm, -1) == -1)) { */
-    /*         if (olvl >= O_NORMAL) */
-    /*             fprintf(stderr, "Couldn't play music: %s\n", Mix_GetError()); */
-    /*     } */
-    /* } */
+    if (!Mix_PlayingMusic()) {
+        if ((Mix_PlayMusic(bgm, -1) == -1)) {
+            if (olvl >= O_NORMAL)
+                fprintf(stderr, "Couldn't play music: %s\n", Mix_GetError());
+        }
+    }
 }
 
 /**
@@ -129,5 +129,5 @@ void playBGM(void)
  */
 void stopBGM(void)
 {
-    /* Mix_HaltMusic(); */
+    Mix_HaltMusic();
 }

--- a/src/zatackax.c
+++ b/src/zatackax.c
@@ -2234,9 +2234,9 @@ int main(void)
                 SDL_Delay(1000/FPS_CAP - delta);
             }
 
-            /* if (curScene->logicFunc()) { */
-            /*     curScene->displayFunc(); */
-            /* } */
+            if (curScene->logicFunc()) {
+                 curScene->displayFunc();
+            }
         }
     }
 

--- a/src/zatackax.c
+++ b/src/zatackax.c
@@ -1918,10 +1918,9 @@ void putPixel(int x, int y, SDL_Color c, unsigned char *target)
  */
 void colorFill(SDL_Color c, SDL_Surface *sprite)
 {
-    unsigned char *target = sprite->pixels;
-
     for (int yy = 0; yy < sprite->h; ++yy) {
-        for (int xx = 0; xx < sprite->w; ++xx, target += 4) {
+        for (int xx = 0; xx < sprite->w; ++xx) {
+            unsigned char *target = (unsigned char *) sprite->pixels + yy * sprite->pitch + xx * sprite->format->BytesPerPixel;
             target[0] *= c.b / 255.0;
             target[1] *= c.g / 255.0;
             target[2] *= c.r / 255.0;

--- a/src/zatackax.c
+++ b/src/zatackax.c
@@ -145,29 +145,29 @@ void resetPlayer(int player)
 
     switch (player) {
     case 0:
-        p->lkey = SDLK_LEFT; p->rkey = SDLK_RIGHT;
-        p->wkey = SDLK_UP;
+        p->lkey = SDL_SCANCODE_LEFT; p->rkey = SDL_SCANCODE_RIGHT;
+        p->wkey = SDL_SCANCODE_UP;
         break;
     case 1:
-        p->lkey = 'z'; p->rkey = 'c'; p->wkey = 'x';
+        p->lkey = SDL_SCANCODE_Z; p->rkey = SDL_SCANCODE_C; p->wkey = SDL_SCANCODE_X;
         break;
     case 2:
-        p->lkey = 'v'; p->rkey = 'n'; p->wkey = 'b';
+        p->lkey = SDL_SCANCODE_V; p->rkey = SDL_SCANCODE_N; p->wkey = SDL_SCANCODE_B;
         break;
     case 3:
-        p->lkey = ','; p->rkey = '-'; p->wkey = '.';
+        p->lkey = SDL_SCANCODE_COMMA; p->rkey = SDL_SCANCODE_MINUS; p->wkey = SDL_SCANCODE_PERIOD;
         break;
     case 4:
-        p->lkey = 'q'; p->rkey = 'e'; p->wkey = 'w';
+        p->lkey = SDL_SCANCODE_Q; p->rkey = SDL_SCANCODE_E; p->wkey = SDL_SCANCODE_W;
         break;
     case 5:
-        p->lkey = 'r'; p->rkey = 'y'; p->wkey = 't';
+        p->lkey = SDL_SCANCODE_R; p->rkey = SDL_SCANCODE_Y; p->wkey = SDL_SCANCODE_T;
         break;
     case 6:
-        p->lkey = 'i'; p->rkey = 'p'; p->wkey = 'o';
+        p->lkey = SDL_SCANCODE_I; p->rkey = SDL_SCANCODE_P; p->wkey = SDL_SCANCODE_O;
         break;
     case 7:
-        p->lkey = SDLK_F1; p->rkey = SDLK_F3; p->wkey = SDLK_F2;
+        p->lkey = SDL_SCANCODE_F1; p->rkey = SDL_SCANCODE_F3; p->wkey = SDL_SCANCODE_F2;
         break;
     default:
         break;
@@ -432,7 +432,7 @@ void setNextKey(unsigned char pedit, unsigned char key)
                 }
                 else {
                     if (event.type == SDL_KEYDOWN) {
-                        k = event.key.keysym.sym;
+                        k = event.key.keysym.scancode;
                     }
                     else {
                         k = event.button.button;
@@ -477,9 +477,9 @@ void setNextKey(unsigned char pedit, unsigned char key)
 void setNextName(unsigned char pedit)
 {
     struct player *p = &players[pedit];
-    bool keyDown[322];
+    bool keyDown[SDL_NUM_SCANCODES];
 
-    memset(keyDown, '\0', 322);
+    memset(keyDown, '\0', SDL_NUM_SCANCODES);
     memset(p->name, '\0', PLAYER_NAME_LEN);
     displayPConfMenu();
     int chars = 0;
@@ -496,9 +496,10 @@ void setNextName(unsigned char pedit)
         if (event.type == SDL_KEYDOWN) {
 
             int k = event.key.keysym.sym;
+            int scan = event.key.keysym.scancode;
 
-            if (!keyDown[k]) {
-                keyDown[k] = 1;
+            if (!keyDown[scan]) {
+                keyDown[scan] = 1;
 
                 if (k >= SDLK_EXCLAIM && k <= SDLK_z) {
                     if (event.key.keysym.mod & KMOD_LSHIFT ||
@@ -516,19 +517,19 @@ void setNextName(unsigned char pedit)
             }
 
             if (chars > 0 &&
-                (k == SDLK_ESCAPE || k == SDLK_RETURN ||
-                 k == SDLK_DOWN   || k == SDLK_UP)) {
+                (scan == SDL_SCANCODE_ESCAPE || scan == SDL_SCANCODE_RETURN ||
+                 scan == SDL_SCANCODE_DOWN   || scan == SDL_SCANCODE_UP)) {
 
                 playSound(SOUND_BEEP, sound);
 
-                if (k == SDLK_DOWN)
+                if (scan == SDL_SCANCODE_DOWN)
                     menuPConf.choice++;
-                else if (k == SDLK_UP)
+                else if (scan == SDL_SCANCODE_UP)
                     menuPConf.choice = menuPConf.choices - 1;
                 return;
             }
         } else if (event.type == SDL_KEYUP)
-            keyDown[event.key.keysym.sym] = 0;
+            keyDown[event.key.keysym.scancode] = 0;
     }
 }
 
@@ -1552,8 +1553,8 @@ int logicSettingsMenu(void)
         }
         return 1;
     }
-    else if (keyDown[SDLK_BACKSPACE]) {
-        keyDown[SDLK_BACKSPACE] = 0;
+    else if (keyDown[SDL_SCANCODE_BACKSPACE]) {
+        keyDown[SDL_SCANCODE_BACKSPACE] = 0;
         if (menuSettings.choice == 9) {
             playSound(SOUND_BEP, sound);
             scorecap = 0;
@@ -1564,16 +1565,16 @@ int logicSettingsMenu(void)
     /* Special case for the score setting */
     if (menuSettings.choice == 9) {
         int num = -1;
-        if      (keyDown[SDLK_0]) num = 0;
-        else if (keyDown[SDLK_1]) num = 1;
-        else if (keyDown[SDLK_2]) num = 2;
-        else if (keyDown[SDLK_3]) num = 3;
-        else if (keyDown[SDLK_4]) num = 4;
-        else if (keyDown[SDLK_5]) num = 5;
-        else if (keyDown[SDLK_6]) num = 6;
-        else if (keyDown[SDLK_7]) num = 7;
-        else if (keyDown[SDLK_8]) num = 8;
-        else if (keyDown[SDLK_9]) num = 9;
+        if      (keyDown[SDL_SCANCODE_0]) num = 0;
+        else if (keyDown[SDL_SCANCODE_1]) num = 1;
+        else if (keyDown[SDL_SCANCODE_2]) num = 2;
+        else if (keyDown[SDL_SCANCODE_3]) num = 3;
+        else if (keyDown[SDL_SCANCODE_4]) num = 4;
+        else if (keyDown[SDL_SCANCODE_5]) num = 5;
+        else if (keyDown[SDL_SCANCODE_6]) num = 6;
+        else if (keyDown[SDL_SCANCODE_7]) num = 7;
+        else if (keyDown[SDL_SCANCODE_8]) num = 8;
+        else if (keyDown[SDL_SCANCODE_9]) num = 9;
 
         if (num != -1) {
             scorecap = scorecap * 10 + num;
@@ -1582,9 +1583,9 @@ int logicSettingsMenu(void)
             }
             playSound(SOUND_BEEP, sound);
 
-            keyDown[SDLK_0] = keyDown[SDLK_1] = keyDown[SDLK_2] = keyDown[SDLK_3] =
-                keyDown[SDLK_4] = keyDown[SDLK_5] = keyDown[SDLK_6] =
-                keyDown[SDLK_7] = keyDown[SDLK_8] = keyDown[SDLK_9] = 0;
+            keyDown[SDL_SCANCODE_0] = keyDown[SDL_SCANCODE_1] = keyDown[SDL_SCANCODE_2] = keyDown[SDL_SCANCODE_3] =
+                keyDown[SDL_SCANCODE_4] = keyDown[SDL_SCANCODE_5] = keyDown[SDL_SCANCODE_6] =
+                keyDown[SDL_SCANCODE_7] = keyDown[SDL_SCANCODE_8] = keyDown[SDL_SCANCODE_9] = 0;
 
             return 1;
         }
@@ -1705,7 +1706,7 @@ int logicPConfMenu(void)
         switch (menuPConf.choice) {
         case 0:
             // Disable name input with joystick for the time being.
-            if (keyDown[SDLK_SPACE] || keyDown[SDLK_RETURN]) {
+            if (keyDown[SDL_SCANCODE_SPACE] || keyDown[SDL_SCANCODE_RETURN]) {
                 playSound(SOUND_BEEP, sound);
                 setNextName(editPlayer);
             }
@@ -1716,19 +1717,19 @@ int logicPConfMenu(void)
             break;
         case 2:
             playSound(SOUND_BEEP, sound);
-            (&players[editPlayer])->lkey = SDLK_CLEAR;
+            (&players[editPlayer])->lkey = SDL_SCANCODE_CLEAR;
             displayPConfMenu(); /* Update menu before catching key */
             setNextKey(editPlayer, 'l');
             break;
         case 3:
             playSound(SOUND_BEEP, sound);
-            (&players[editPlayer])->wkey = SDLK_CLEAR;
+            (&players[editPlayer])->wkey = SDL_SCANCODE_CLEAR;
             displayPConfMenu(); /* Update menu before catching key */
             setNextKey(editPlayer, 'w');
             break;
         case 4:
             playSound(SOUND_BEEP, sound);
-            (&players[editPlayer])->rkey = SDLK_CLEAR;
+            (&players[editPlayer])->rkey = SDL_SCANCODE_CLEAR;
             displayPConfMenu(); /* Update menu before catching key */
             setNextKey(editPlayer, 'r');
             break;
@@ -1754,8 +1755,8 @@ int logicPConfMenu(void)
             playSound(SOUND_BEEP, sound);
             setColor(editPlayer, 1);
             return 1;
-        } else if (keyDown[SDLK_BACKSPACE]) {
-            keyDown[SDLK_BACKSPACE] = 0;
+        } else if (keyDown[SDL_SCANCODE_BACKSPACE]) {
+            keyDown[SDL_SCANCODE_BACKSPACE] = 0;
             playSound(SOUND_BEEP, sound);
             setNextName(editPlayer);
             return 1;
@@ -2135,7 +2136,7 @@ int main(void)
 
                 int k = -1;
                 if (event.type == SDL_KEYDOWN) {
-                    k = event.key.keysym.sym;
+                    k = event.key.keysym.scancode;
                 }
                 else if (event.type == SDL_MOUSEBUTTONDOWN) {
                     k = event.button.button;
@@ -2147,14 +2148,14 @@ int main(void)
                     k = axisNumber(event.jaxis) << 4;
                 }
 
-                if (screenFreeze && k == SDLK_RETURN) {
+                if (screenFreeze && k == SDL_SCANCODE_RETURN) {
                     screenFreeze = false;
                     endRound();
                     curScene = &mainMenu;
                     curScene->displayFunc();
                 }
 
-                if ((event.type == SDL_KEYDOWN && k == SDLK_ESCAPE)) {
+                if ((event.type == SDL_KEYDOWN && k == SDL_SCANCODE_ESCAPE)) {
                     screenFreeze = false;
                     if (curScene == &game || curScene == &gameStart)
                         endRound();
@@ -2201,7 +2202,7 @@ int main(void)
                 }
             }
             else if (event.type == SDL_KEYUP) {
-                keyDown[event.key.keysym.sym] = false;
+                keyDown[event.key.keysym.scancode] = false;
             }
             else if (event.type == SDL_MOUSEBUTTONUP) {
                 keyDown[event.button.button] = false;

--- a/src/zatackax.c
+++ b/src/zatackax.c
@@ -2103,12 +2103,12 @@ int main(void)
         return 1;
     }
 
-    /* if (!loadSounds()) { */
-    /*     if (olvl >= O_NORMAL) { */
-    /*         fprintf(stderr, "ERROR: Failed to load sound files.\n"); */
-    /*     } */
-    /*     return 1; */
-    /* } */
+    if (!loadSounds()) {
+        if (olvl >= O_NORMAL) {
+            fprintf(stderr, "ERROR: Failed to load sound files.\n");
+        }
+        return 1;
+    }
 
     if (!loadFonts()) {
         if (olvl >= O_NORMAL) {
@@ -2124,8 +2124,8 @@ int main(void)
     curScene = &mainMenu;
     curScene->displayFunc();
 
-    /* if (music) */
-    /*     playBGM(); */
+    if (music)
+        playBGM();
 
     for (;;) {
         while (SDL_PollEvent(&event)) {

--- a/src/zatackax.c
+++ b/src/zatackax.c
@@ -1217,7 +1217,7 @@ void resetWeapons(void)
  */
 void initMainMenu(void)
 {
-    /* colorBalls(); */
+    colorBalls();
 }
 
 /**
@@ -1285,30 +1285,30 @@ void displayMainMenu(void)
     displayMenu(c, &menuMain, ymod);
     SDL_Rect offset = {WINDOW_W / 2 - logo->w / 2, WINDOW_H / 2 - logo->h,
                        0, 0};
-    /* SDL_BlitSurface(logo, NULL, screen, &offset); */
+    SDL_BlitSurface(logo, NULL, screen, &offset);
 
     /* This could/should be made smoother... */
-    /* for (int i = 0; i < nPlayers; ++i) { */
-    /*     offset.x = (WINDOW_W / 2)            /\* window offset *\/ */
-    /*         - 60                             /\* temp. offset *\/ */
-    /*         + (i - nPlayers) * BALL_SPACING; /\* player modifier *\/ */
+    for (int i = 0; i < nPlayers; ++i) {
+        offset.x = (WINDOW_W / 2)            /* window offset */
+            - 60                             /* temp. offset */
+            + (i - nPlayers) * BALL_SPACING; /* player modifier */
 
-    /*     offset.y = (WINDOW_H / 2)            /\* window offset *\/ */
-    /*         - BALL_Y_MOD + ymod;             /\* temp. offset *\/ */
+        offset.y = (WINDOW_H / 2)            /* window offset */
+            - BALL_Y_MOD + ymod;             /* temp. offset */
 
-    /*     SDL_BlitSurface(pballs[i], NULL, screen, &offset); */
-    /* } */
+        SDL_BlitSurface(pballs[i], NULL, screen, &offset);
+    }
 
-    /* for (int i = nPlayers; i < MAX_PLAYERS; ++i) { */
-    /*     offset.x = (WINDOW_W / 2)            /\* window offset *\/ */
-    /*         + 68                             /\* temp. offset *\/ */
-    /*         + (i - nPlayers) * BALL_SPACING; /\* player modifier *\/ */
+    for (int i = nPlayers; i < MAX_PLAYERS; ++i) {
+        offset.x = (WINDOW_W / 2)            /* window offset */
+            + 68                             /* temp. offset */
+            + (i - nPlayers) * BALL_SPACING; /* player modifier */
 
-    /*     offset.y = (WINDOW_H / 2)            /\* window offset *\/ */
-    /*         - BALL_Y_MOD + ymod;             /\* temp. offset *\/ */
+        offset.y = (WINDOW_H / 2)            /* window offset */
+            - BALL_Y_MOD + ymod;             /* temp. offset */
 
-    /*     SDL_BlitSurface(pballs[MAX_PLAYERS], NULL, screen, &offset); */
-    /* } */
+        SDL_BlitSurface(pballs[MAX_PLAYERS], NULL, screen, &offset);
+    }
 
     SDL_UpdateTexture(screen_t, NULL, screen->pixels, screen->pitch);
     SDL_RenderClear(renderer);
@@ -2014,12 +2014,12 @@ void initGraphics(void)
     /* Make arrow copies */
     parrows = malloc(MAX_PLAYERS * sizeof(SDL_Surface *));
     p = parrows;
-        for (int i = 0; i < MAX_PLAYERS; ++i, ++p) {
-        *p = SDL_CreateRGBSurface(0, arrows->w, arrows->h, 32,
-                                  0x00ff0000,
-                                  0x0000ff00,
-                                  0x000000ff,
-                                  0xff000000);
+    for (int i = 0; i < MAX_PLAYERS; ++i, ++p) {
+        *p = SDL_CreateRGBSurface(0, arrows->w, arrows->h, arrows->format->BitsPerPixel,
+                                  arrows->format->Rmask,
+                                  arrows->format->Gmask,
+                                  arrows->format->Bmask,
+                                  arrows->format->Amask);
     }
 
     /* Make ball copies */
@@ -2027,11 +2027,11 @@ void initGraphics(void)
     p = pballs;
     SDL_Surface *ball = images[IMG_BALL];
     for (int i = 0; i < MAX_PLAYERS + 1; ++i, ++p) {
-        *p = SDL_CreateRGBSurface(0, ball->w, ball->h, 32,
-                                  0x00ff0000,
-                                  0x0000ff00,
-                                  0x000000ff,
-                                  0xff000000);
+        *p = SDL_CreateRGBSurface(ball->flags, ball->w, ball->h, ball->format->BitsPerPixel,
+                                  ball->format->Rmask,
+                                  ball->format->Gmask,
+                                  ball->format->Bmask,
+                                  ball->format->Amask);
     }
 
     /* Initialize weapon pointer array */

--- a/src/zatackax.c
+++ b/src/zatackax.c
@@ -1986,7 +1986,7 @@ int init(void)
 
     SDL_ShowCursor(SDL_DISABLE);
     SDL_Surface *icon = loadIcon("icon.bmp");
-    /* SDL_WM_SetIcon(icon, NULL); */
+    SDL_SetWindowIcon(window, icon);
     SDL_FreeSurface(icon);
 
     return 1;
@@ -2087,10 +2087,10 @@ int main(void)
     initPlayers1();
     restoreSettings();
 
-    if (!init())
+    if (!initScreen())
         return 1;
 
-    if (!initScreen())
+    if (!init())
         return 1;
 
     initHitMap(WINDOW_W, WINDOW_H);

--- a/src/zatackax.h
+++ b/src/zatackax.h
@@ -155,7 +155,7 @@ int handleMenu(struct menu *m);
 void displayMenu(char *c[], struct menu *m, int ymod);
 
 /* GRAPHICS */
-void putPixel(int x, int y, SDL_Color c, unsigned char *target);
+void putPixel(int x, int y, SDL_Color c, SDL_Surface *target);
 void colorFill(SDL_Color c, SDL_Surface *sprite);
 void colorBalls(void);
 


### PR DESCRIPTION
This PR aims to restore the SDL2 port to a playable state with a reasonable amount of parity. See issue #3.

Tested on my own laptop only, and have done some comparisons with the SDL1 version.
### Notable changes
* Reverted removal of music and sound effects
* For a large part using scancodes instead of keycodes
* Fixups with respect to surface pixel formats and surface locking

### Not tested
* Particles
* Performance
* Experience on computers with another endian